### PR TITLE
feat: 로그인 기능 구현, 로그인시 JWT 반환하도록

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Created by https://www.toptal.com/developers/gitignore/api/java,macos,windows,node,zsh,visualstudiocode,eclipse,intellij,maven,gradle
 # Edit at https://www.toptal.com/developers/gitignore?templates=java,macos,windows,node,zsh,visualstudiocode,eclipse,intellij,maven,gradle
 
+.env
+
 ### Eclipse ###
 .metadata
 bin/

--- a/src/main/java/com/example/floud/config/AppConfig.java
+++ b/src/main/java/com/example/floud/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.example.floud.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/floud/config/SecurityConfig.java
+++ b/src/main/java/com/example/floud/config/SecurityConfig.java
@@ -8,14 +8,9 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 
-import com.example.floud.util.JwtProvider;
-
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
-
-
-    private final JwtProvider jwtProvider;
 
     @Override
     public void configure(WebSecurity web) throws Exception

--- a/src/main/java/com/example/floud/config/SecurityConfig.java
+++ b/src/main/java/com/example/floud/config/SecurityConfig.java
@@ -1,38 +1,26 @@
 package com.example.floud.config;
 
-import com.example.floud.entity.User;
-import com.example.floud.repository.UserRepository;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
+import com.example.floud.util.JwtProvider;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 
+    private final JwtProvider jwtProvider;
+
     @Override
     public void configure(WebSecurity web) throws Exception
     {
-        web.ignoring().antMatchers("/css/**", "/script/**", "image/**", "/fonts/**", "lib/**","/signup");
+        web.ignoring().antMatchers("/css/**", "/script/**", "image/**", "/fonts/**", "lib/**","/signup","/login");
     }
     @Override
     protected void configure(HttpSecurity http) throws Exception
@@ -42,4 +30,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/**").permitAll();
     }
 
+    @Override
+    @Bean
+    protected AuthenticationManager authenticationManager() throws Exception {
+        return super.authenticationManager();
+    }
 }

--- a/src/main/java/com/example/floud/controller/UserController.java
+++ b/src/main/java/com/example/floud/controller/UserController.java
@@ -1,11 +1,16 @@
 package com.example.floud.controller;
 
+import com.example.floud.dto.JwtToken;
+import com.example.floud.dto.LoginFormDto;
 import com.example.floud.dto.UserFormDto;
 import com.example.floud.entity.User;
 import com.example.floud.service.UserService;
+import io.jsonwebtoken.Jwt;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping
@@ -13,6 +18,8 @@ public class UserController {
 
     @Autowired
     private UserService userService;
+
+    private LoginFormDto loginFormDto;
 
     // 유저 ID로 사용자를 조회
     @GetMapping("/{id}")
@@ -26,12 +33,18 @@ public class UserController {
     @PostMapping("/signup")
     public ResponseEntity<?> signup(
             @RequestBody UserFormDto user) {
-        try{
+        try {
             ResponseEntity<?> registeredUser = userService.signup(user);
             return ResponseEntity.ok(registeredUser);
 
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(e.getMessage());  // 오류 응답
         }
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<JwtToken> login(@RequestBody LoginFormDto loginFormDto) {
+        JwtToken token = userService.login(loginFormDto.getLoginId(), loginFormDto.getPassword());
+        return ResponseEntity.ok(token);
     }
 }

--- a/src/main/java/com/example/floud/controller/UserController.java
+++ b/src/main/java/com/example/floud/controller/UserController.java
@@ -5,12 +5,9 @@ import com.example.floud.dto.LoginFormDto;
 import com.example.floud.dto.UserFormDto;
 import com.example.floud.entity.User;
 import com.example.floud.service.UserService;
-import io.jsonwebtoken.Jwt;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping
@@ -18,8 +15,6 @@ public class UserController {
 
     @Autowired
     private UserService userService;
-
-    private LoginFormDto loginFormDto;
 
     // 유저 ID로 사용자를 조회
     @GetMapping("/{id}")

--- a/src/main/java/com/example/floud/dto/JwtToken.java
+++ b/src/main/java/com/example/floud/dto/JwtToken.java
@@ -1,0 +1,15 @@
+package com.example.floud.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class JwtToken {
+
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/example/floud/dto/LoginFormDto.java
+++ b/src/main/java/com/example/floud/dto/LoginFormDto.java
@@ -1,0 +1,19 @@
+package com.example.floud.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+
+@NoArgsConstructor
+@Getter
+public class LoginFormDto {
+
+    @NotBlank(message = "아이디는 필수 입력 값입니다.")
+    private String loginId;
+
+    @NotEmpty(message = "비밀번호는 필수 입력 값입니다.")
+    private String password;
+
+}

--- a/src/main/java/com/example/floud/dto/ResponseDto.java
+++ b/src/main/java/com/example/floud/dto/ResponseDto.java
@@ -1,4 +1,0 @@
-package com.example.floud.dto;
-
-public class ResponseDto {
-}

--- a/src/main/java/com/example/floud/dto/UserFormDto.java
+++ b/src/main/java/com/example/floud/dto/UserFormDto.java
@@ -24,7 +24,6 @@ public class UserFormDto {
     private String email;
 
     @NotEmpty(message = "비밀번호는 필수 입력 값입니다.")
-    @Length(min = 4, max = 16, message = "비밀번호는 4자 이상, 16자 이하로 입력해주세요.")
     private String password;
 
     @NotEmpty(message = "번호는 필수 입력 값입니다.")

--- a/src/main/java/com/example/floud/dto/UserFormDto.java
+++ b/src/main/java/com/example/floud/dto/UserFormDto.java
@@ -33,7 +33,8 @@ public class UserFormDto {
     private LocalDate birth;
 
     @Builder
-    public UserFormDto(String username, String email, String password, String phone, LocalDate birth) {
+    public UserFormDto(String loginId, String username, String email, String password, String phone, LocalDate birth) {
+        this.loginId = loginId;
         this.username = username;
         this.email = email;
         this.password = password;

--- a/src/main/java/com/example/floud/repository/UserRepository.java
+++ b/src/main/java/com/example/floud/repository/UserRepository.java
@@ -14,4 +14,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByPhone(String phone);
 
     Optional<User> findByUsername(String username);
+    Optional<User> findByLoginId(String loginId);
 }

--- a/src/main/java/com/example/floud/service/UserDetailServiceImpl.java
+++ b/src/main/java/com/example/floud/service/UserDetailServiceImpl.java
@@ -15,12 +15,14 @@ import java.util.Optional;
 @Service
 public class UserDetailServiceImpl implements UserDetailsService {
 
+
+
     @Autowired
     UserRepository userRepository;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByUsername(username)
+        User user = userRepository.findByLoginId(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with username: " + username));
 
         return new org.springframework.security.core.userdetails.User(

--- a/src/main/java/com/example/floud/service/UserService.java
+++ b/src/main/java/com/example/floud/service/UserService.java
@@ -1,20 +1,23 @@
 package com.example.floud.service;
 
-import com.example.floud.dto.ResponseDto;
+import com.example.floud.dto.JwtToken;
 import com.example.floud.dto.UserFormDto;
 import com.example.floud.entity.User;
 import com.example.floud.repository.UserRepository;
+import com.example.floud.util.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.net.HttpURLConnection;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -23,14 +26,24 @@ import java.util.Optional;
 public class UserService {
 
     @Autowired
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Autowired
     private UserRepository userRepository;
+    private AuthenticationManagerBuilder authenticationManagerBuilder;
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
 
     public Optional<User> getUserById(Long userId) {
         return userRepository.findById(userId);
     }
 
     public ResponseEntity<?> signup(UserFormDto userFormDto) {
-        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
         User user = User.builder()
                 .loginId(userFormDto.getLoginId())
                 .password(passwordEncoder.encode(userFormDto.getPassword()))
@@ -43,6 +56,27 @@ public class UserService {
         isEmailAlreadyRegistered(user.getEmail());
         userRepository.save(user);
         return ResponseEntity.ok().body(user);
+    }
+
+    public JwtToken login(String loginId, String rawPassword) {
+        // 사용자 정보 조회
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        System.out.println("Raw password: {}" + rawPassword);
+        System.out.println("Encoded password in DB: {}" + user.getPassword());
+        System.out.println("loginId = " + loginId);
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
+            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // 인증 토큰 생성 및 인증 과정 수행
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(loginId, rawPassword);
+        Authentication authentication = authenticationManager.authenticate(authenticationToken);
+        // JWT 토큰 생성
+        JwtToken token = jwtProvider.generateToken(authentication);
+        return token;
     }
 
     private boolean isPhoneAlreadyRegistered(String phone) {

--- a/src/main/java/com/example/floud/service/UserService.java
+++ b/src/main/java/com/example/floud/service/UserService.java
@@ -11,7 +11,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -30,7 +29,6 @@ public class UserService {
 
     @Autowired
     private UserRepository userRepository;
-    private AuthenticationManagerBuilder authenticationManagerBuilder;
 
     @Autowired
     private AuthenticationManager authenticationManager;
@@ -63,15 +61,12 @@ public class UserService {
         User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 
-        System.out.println("Raw password: {}" + rawPassword);
-        System.out.println("Encoded password in DB: {}" + user.getPassword());
-        System.out.println("loginId = " + loginId);
         // 비밀번호 검증
         if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
             throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
         }
 
-        // 인증 토큰 생성 및 인증 과정 수행
+        // 토큰 생성 및 인증
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(loginId, rawPassword);
         Authentication authentication = authenticationManager.authenticate(authenticationToken);
         // JWT 토큰 생성
@@ -88,8 +83,4 @@ public class UserService {
         Optional<User> user = userRepository.findByEmail(email);
         return user.isPresent();
     }
-
-
-
-
 }

--- a/src/main/java/com/example/floud/util/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/floud/util/JwtAuthenticationFilter.java
@@ -1,0 +1,38 @@
+package com.example.floud.util;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+
+    private JwtProvider jwtProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        String token = resolveToken((HttpServletRequest) request);
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            Authentication authentication = jwtProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/floud/util/JwtProvider.java
+++ b/src/main/java/com/example/floud/util/JwtProvider.java
@@ -1,0 +1,106 @@
+package com.example.floud.util;
+
+import com.example.floud.FloudApplication;
+import com.example.floud.dto.JwtToken;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.xml.bind.DatatypeConverter;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+    private Key key;
+
+    public JwtProvider(@Value("${spring.jwt.secret}") String secretKey) {
+        try {
+            log.info("JWT Secret Key: {}", secretKey);
+            byte[] secretByteKey = DatatypeConverter.parseBase64Binary(secretKey);
+            this.key = Keys.hmacShaKeyFor(secretByteKey);
+        } catch (IllegalArgumentException e) {
+            log.error("Error parsing JWT secret key", e);
+            // 적절한 예외 처리 또는 대체 로직을 구현할 수 있습니다.
+        }
+    }
+
+
+
+    public JwtToken generateToken(Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth", authorities)
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 30))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 36))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return JwtToken.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get("auth") == null) {
+            throw new RuntimeException("권한 정보가 업는 토큰입니다.");
+        }
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get("auth").toString()
+                        .split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJwt(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT TOKEN", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expires JWT TOKEN", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT TOKEN", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty", e);
+        }
+        return false;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,8 @@
+{
+  "properties": [
+    {
+      "name": "spring.jwt",
+      "type": "java.lang.String",
+      "description": "Description for spring.jwt."
+  }
+] }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  jwt:
+    secret: hdqkwhdwqkjlfkeqjwrklqjdklsajklejqdkjqdjhn1@!#@#!@$@!$#%#@$^$%#@!$!lkfeqwklfdn@!#@!#
   jackson:
     time-zone: Asia/Seoul
     serialization:
@@ -10,7 +12,6 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     database-platform: org.hibernate.dialect.MySQL57Dialect
-
     open-in-view: false
     show-sql: true
     hibernate:


### PR DESCRIPTION
# 📌이 풀리퀘스트는 다음과 같습니다.

로그인 API 구현

## 🤔배경

## 📁 작업내용

로그인시 client 에게 JWT, refresh 토큰 뱉어내도록 함

<img width="646" alt="스크린샷 2023-11-15 오후 12 52 31" src="https://github.com/goormthon-Univ/TEAM_2_BE/assets/89504367/b9b5aa3e-ce97-4346-b6c5-c7094b8ef4ee">

## ✅ 체크리스트

### 🧑🏻‍💻코드
- [x] 스스로 코드를 검토하고 오타를 수정했습니다.
- [x] 코드 내에 이해하기 어려운 부분이 있는지 확인하고, 필요의 경우 주석을 추가했습니다.
- [x] 콘솔에서 경고(warning)가 발생하지 않습니다.
- [x] console.log, 테스트 주석 등 의미 없는 코드를 제거하였습니다.