### PR TITLE
feat: 로그인시 userId 및 토큰 값 같이 보내도록 수정

### DIFF
--- a/src/main/java/com/example/floud/controller/UserController.java
+++ b/src/main/java/com/example/floud/controller/UserController.java
@@ -2,10 +2,14 @@ package com.example.floud.controller;
 
 import com.example.floud.dto.JwtToken;
 import com.example.floud.dto.LoginFormDto;
+import com.example.floud.dto.LoginResponseDto;
 import com.example.floud.dto.UserFormDto;
 import com.example.floud.entity.User;
+import com.example.floud.repository.UserRepository;
 import com.example.floud.service.UserService;
+import com.example.floud.util.JwtProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,6 +19,10 @@ public class UserController {
 
     @Autowired
     private UserService userService;
+
+    private UserRepository userRepository;
+
+    private JwtProvider jwtProvider;
 
     // 유저 ID로 사용자를 조회
     @GetMapping("/{id}")
@@ -38,8 +46,12 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<JwtToken> login(@RequestBody LoginFormDto loginFormDto) {
-        JwtToken token = userService.login(loginFormDto.getLoginId(), loginFormDto.getPassword());
-        return ResponseEntity.ok(token);
+    public ResponseEntity<LoginResponseDto> login(@RequestBody LoginFormDto loginFormDto) {
+        LoginResponseDto.Data data = userService.login(loginFormDto.getLoginId(), loginFormDto.getPassword());
+        Long userId = data.getUserId();
+        LoginResponseDto.Data responseData = new LoginResponseDto.Data(userId, data.getAccessToken(), data.getRefreshToken());
+        LoginResponseDto response = new LoginResponseDto("로그인 성공", responseData);
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/floud/dto/JwtToken.java
+++ b/src/main/java/com/example/floud/dto/JwtToken.java
@@ -8,8 +8,11 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class JwtToken {
-
     private String grantType;
     private String accessToken;
     private String refreshToken;
+
+    public String getAccessToken() {
+        return accessToken;
+    }
 }

--- a/src/main/java/com/example/floud/dto/LoginFormDto.java
+++ b/src/main/java/com/example/floud/dto/LoginFormDto.java
@@ -1,19 +1,23 @@
 package com.example.floud.dto;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 
+@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 public class LoginFormDto {
+
+    @NotBlank
+    private Long userId;
 
     @NotBlank(message = "아이디는 필수 입력 값입니다.")
     private String loginId;
 
     @NotEmpty(message = "비밀번호는 필수 입력 값입니다.")
     private String password;
+
 
 }

--- a/src/main/java/com/example/floud/dto/LoginResponseDto.java
+++ b/src/main/java/com/example/floud/dto/LoginResponseDto.java
@@ -1,0 +1,31 @@
+package com.example.floud.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginResponseDto {
+    private String message;
+    private Data data;
+
+    public LoginResponseDto(String message, Data data) {
+        this.message = message;
+        this.data = data;
+    }
+
+    @Getter
+    public static class Data {
+        private Long userId;
+        private String accessToken;
+        private String refreshToken;
+
+
+        public Data(Long userId, String accessToken, String refreshToken) {
+            this.userId = userId;
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+        }
+
+    }
+}

--- a/src/main/java/com/example/floud/repository/UserRepository.java
+++ b/src/main/java/com/example/floud/repository/UserRepository.java
@@ -7,8 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findById(Long userId);
-
     Optional<User> findByEmail(String email);
 
     Optional<User> findByPhone(String phone);

--- a/src/main/java/com/example/floud/service/UserService.java
+++ b/src/main/java/com/example/floud/service/UserService.java
@@ -1,6 +1,7 @@
 package com.example.floud.service;
 
 import com.example.floud.dto.JwtToken;
+import com.example.floud.dto.LoginResponseDto;
 import com.example.floud.dto.UserFormDto;
 import com.example.floud.entity.User;
 import com.example.floud.repository.UserRepository;
@@ -56,7 +57,7 @@ public class UserService {
         return ResponseEntity.ok().body(user);
     }
 
-    public JwtToken login(String loginId, String rawPassword) {
+    public LoginResponseDto.Data login(String loginId, String rawPassword) {
         // 사용자 정보 조회
         User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
@@ -71,7 +72,7 @@ public class UserService {
         Authentication authentication = authenticationManager.authenticate(authenticationToken);
         // JWT 토큰 생성
         JwtToken token = jwtProvider.generateToken(authentication);
-        return token;
+        return new LoginResponseDto.Data(user.getId(), token.getAccessToken(),token.getRefreshToken());
     }
 
     private boolean isPhoneAlreadyRegistered(String phone) {

--- a/src/main/java/com/example/floud/util/JwtProvider.java
+++ b/src/main/java/com/example/floud/util/JwtProvider.java
@@ -19,6 +19,7 @@ import java.security.Key;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -41,9 +42,11 @@ public class JwtProvider {
 
 
     public JwtToken generateToken(Authentication authentication) {
+
         String authorities = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
+
 
         String accessToken = Jwts.builder()
                 .setSubject(authentication.getName())
@@ -95,6 +98,17 @@ public class JwtProvider {
         }
         return false;
     }
+
+    public Long getUserIdFromToken(JwtToken token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token.getAccessToken()) // JWT 토큰 문자열 사용
+                .getBody();
+
+        return claims.get("userId", Long.class);
+    }
+
 
     private Claims parseClaims(String accessToken) {
         try {


### PR DESCRIPTION
# 📌이 풀리퀘스트는 다음과 같습니다.

로그인 API 컨벤션에 따라 response 타입 수정

## 📁 작업내용

<img width="648" alt="스크린샷 2023-11-15 오후 4 10 12" src="https://github.com/goormthon-Univ/TEAM_2_BE/assets/89504367/1e9e31e6-7c4a-424a-8674-b43a96a085b1">

## ✅ 체크리스트


### 🧑🏻‍💻코드
- [x] 스스로 코드를 검토하고 오타를 수정했습니다.
- [x] 코드 내에 이해하기 어려운 부분이 있는지 확인하고, 필요의 경우 주석을 추가했습니다.
- [x] 콘솔에서 경고(warning)가 발생하지 않습니다.
- [x] console.log, 테스트 주석 등 의미 없는 코드를 제거하였습니다.