### PR TITLE
feat: memoir 엔티티 생성

### DIFF
--- a/src/main/java/com/example/floud/entity/Memoir.java
+++ b/src/main/java/com/example/floud/entity/Memoir.java
@@ -37,4 +37,9 @@ public class Memoir {
 
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/example/floud/entity/Memoir.java
+++ b/src/main/java/com/example/floud/entity/Memoir.java
@@ -1,0 +1,39 @@
+package com.example.floud.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.persistence.*;
+import java.util.Date;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "memoirs")
+public class Memoir {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "memoir_id", unique = true, nullable = false)
+    private Long id;
+
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @Column(length = 50, nullable = false)
+    private String title;
+
+    @Column
+    private String memoirKeep;
+
+    @Column
+    private String memoirProblem;
+
+    @Column
+    private String memoirTry;
+
+    @Column(nullable = false, updatable = false)
+    private Date createdAt;
+}

--- a/src/main/java/com/example/floud/entity/Memoir.java
+++ b/src/main/java/com/example/floud/entity/Memoir.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.Date;
 
 @Entity
@@ -25,15 +26,15 @@ public class Memoir {
     @Column(length = 50, nullable = false)
     private String title;
 
-    @Column
+    @Column(columnDefinition = "TEXT")
     private String memoirKeep;
 
-    @Column
+    @Column(columnDefinition = "TEXT")
     private String memoirProblem;
 
-    @Column
+    @Column(columnDefinition = "TEXT")
     private String memoirTry;
 
     @Column(nullable = false, updatable = false)
-    private Date createdAt;
+    private LocalDateTime createdAt;
 }


### PR DESCRIPTION
# 📌이 풀리퀘스트는 다음과 같습니다.

회고(memoir) 엔티티를 생성

## 📁 작업내용

회고 엔티티를 생성했습니다.
varchar 에서 TEXT type으로 수정하였습니다.
회고 등록시 현재시간이 등록되도록 onCreate() 추가

## ✅ 체크리스트


### 🧑🏻‍💻코드
- [x] 스스로 코드를 검토하고 오타를 수정했습니다.
- [x] 코드 내에 이해하기 어려운 부분이 있는지 확인하고, 필요의 경우 주석을 추가했습니다.
- [x] 콘솔에서 경고(warning)가 발생하지 않습니다.
- [x] console.log, 테스트 주석 등 의미 없는 코드를 제거하였습니다.