### PR TITLE
feat: 회고 조회시 좋아요 카운트 노출

### DIFF
--- a/src/main/java/com/example/floud/dto/response/memoir/MemoirAnonymousResponseDto.java
+++ b/src/main/java/com/example/floud/dto/response/memoir/MemoirAnonymousResponseDto.java
@@ -19,6 +19,8 @@ public class MemoirAnonymousResponseDto {
     private String memoirKeep;
     private String memoirProblem;
     private String memoirTry;
+    private int commentCount;
+    private int likeCount;
     private List<Comment> commentList;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/example/floud/dto/response/memoir/MemoirGetOneResponseDto.java
+++ b/src/main/java/com/example/floud/dto/response/memoir/MemoirGetOneResponseDto.java
@@ -1,6 +1,7 @@
 package com.example.floud.dto.response.memoir;
 
 import com.example.floud.entity.Comment;
+import com.example.floud.entity.MemoirLike;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,6 +21,9 @@ public class MemoirGetOneResponseDto {
     private String memoirProblem;
     private String memoirTry;
     private List<Comment> commentList;
+    private int commentCount;
+    private int likeCount;
+    private List<MemoirLike> memoirLikeList;
     private LocalDateTime createdAt;
 
 }

--- a/src/main/java/com/example/floud/entity/Memoir.java
+++ b/src/main/java/com/example/floud/entity/Memoir.java
@@ -47,7 +47,6 @@ public class Memoir {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-
     @JsonManagedReference
     @OneToMany(mappedBy = "memoir", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<Comment> commentList = new ArrayList<>();

--- a/src/main/java/com/example/floud/repository/MemoirLikeRepository.java
+++ b/src/main/java/com/example/floud/repository/MemoirLikeRepository.java
@@ -9,4 +9,7 @@ import java.util.List;
 public interface MemoirLikeRepository extends JpaRepository<MemoirLike, Long> {
     List<MemoirLike> findByUserIdAndLikeDateBetween(Long userId, LocalDate startDate, LocalDate endDate);
 
+    int countByMemoirId(Long memoir_id);
+
+
 }

--- a/src/main/java/com/example/floud/service/MemoirService.java
+++ b/src/main/java/com/example/floud/service/MemoirService.java
@@ -51,6 +51,8 @@ public class MemoirService {
                 .orElseThrow(() -> new RuntimeException("해당 회고 정보가 존재하지 않습니다. memoir_id = " + memoir_id));
 
         Hibernate.initialize(oneMemoir.getCommentList());
+        int commentCount = oneMemoir.getCommentList() != null ? oneMemoir.getCommentList().size() : 0;
+        int likeCount = memoirLikeRepository.countByMemoirId(memoir_id); // 좋아요 개수 계산
 
         return MemoirGetOneResponseDto.builder()
                 .user_id(oneMemoir.getUser().getId())
@@ -59,6 +61,8 @@ public class MemoirService {
                 .memoirKeep(oneMemoir.getMemoirKeep())
                 .memoirProblem(oneMemoir.getMemoirProblem())
                 .memoirTry(oneMemoir.getMemoirTry())
+                .likeCount(likeCount)
+                .commentCount(commentCount)
                 .commentList(oneMemoir.getCommentList())
                 .createdAt(LocalDateTime.parse(oneMemoir.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))))
                 .build();
@@ -71,13 +75,14 @@ public class MemoirService {
             throw new RuntimeException("No memoirs available for anonymous viewing.");
         }
 
-
         Random random = new Random();
         Long randomMemoirId = memoirIds.get(random.nextInt(memoirIds.size()));
         Memoir memoir = memoirRepository.findById(randomMemoirId)
                 .orElseThrow(() -> new RuntimeException("Memoir not found with id: " + randomMemoirId));
 
         memoir.getCommentList().forEach(comment -> Hibernate.initialize(comment.getAlarmList()));
+        int commentCount = memoir.getCommentList() != null ? memoir.getCommentList().size() : 0;
+        int likeCount = memoirLikeRepository.countByMemoirId(randomMemoirId); // 좋아요 개수 계산
 
 
         return MemoirAnonymousResponseDto.builder()
@@ -87,6 +92,8 @@ public class MemoirService {
                 .memoirKeep(memoir.getMemoirKeep())
                 .memoirProblem(memoir.getMemoirProblem())
                 .memoirTry(memoir.getMemoirTry())
+                .likeCount(likeCount)
+                .commentCount(commentCount)
                 .commentList(memoir.getCommentList())
                 .createdAt(LocalDateTime.parse(memoir.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"))))
                 .build();


### PR DESCRIPTION
# 📌이 풀리퀘스트는 다음과 같습니다.

익명회고, 단건회고 조회시 좋아요 카운트 노출되도록 수정

## 📁 작업내용

<img width="730" alt="스크린샷 2023-11-17 오후 4 49 20" src="https://github.com/goormthon-Univ/TEAM_2_BE/assets/89504367/1c23cb68-b5e2-41e6-bef1-f2e4e6f1aec9">


## ✅ 체크리스트


### 🧑🏻‍💻코드
- [x] 스스로 코드를 검토하고 오타를 수정했습니다.
- [x] 코드 내에 이해하기 어려운 부분이 있는지 확인하고, 필요의 경우 주석을 추가했습니다.
- [x] 콘솔에서 경고(warning)가 발생하지 않습니다.
- [x] console.log, 테스트 주석 등 의미 없는 코드를 제거하였습니다.